### PR TITLE
Early extraction of duration metadata via playlist thumbnail overlay

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -319,8 +319,8 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         duration_text = try_get(
             renderer, 
             (lambda x: x['lengthText']['simpleText'], 
-             lambda x: x['thumbnailOverlays'][0]['thumbnailOverlayTimeStatusRenderer']['text']['simpleText']),
-             compat_str)
+            lambda x: x['thumbnailOverlays'][0]['thumbnailOverlayTimeStatusRenderer']['text']['simpleText']),
+            compat_str)
         duration = parse_duration(duration_text)
         view_count_text = try_get(
             renderer, lambda x: x['viewCountText']['simpleText'], compat_str) or ''

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -318,7 +318,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             compat_str)
         duration_text = try_get(
             renderer, 
-           (lambda x: x['lengthText']['simpleText'], 
+           (lambda x: x['lengthText']['simpleText'],
             lambda x: x['thumbnailOverlays'][0]['thumbnailOverlayTimeStatusRenderer']['text']['simpleText']),
             compat_str)
         duration = parse_duration(duration_text)

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -315,11 +315,11 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
              lambda x: x['title']['simpleText']), compat_str)
         description = try_get(
             renderer, lambda x: x['descriptionSnippet']['runs'][0]['text'],
-            compat_str)
+            compat_str) 
         duration_text = try_get(
-            renderer, 
-           (lambda x: x['lengthText']['simpleText'],
-            lambda x: x['thumbnailOverlays'][0]['thumbnailOverlayTimeStatusRenderer']['text']['simpleText']),
+            renderer,
+            (lambda x: x['lengthText']['simpleText'],
+             lambda x: x['thumbnailOverlays'][0]['thumbnailOverlayTimeStatusRenderer']['text']['simpleText']),
             compat_str)
         duration = parse_duration(duration_text)
         view_count_text = try_get(

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -316,8 +316,12 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         description = try_get(
             renderer, lambda x: x['descriptionSnippet']['runs'][0]['text'],
             compat_str)
-        duration = parse_duration(try_get(
-            renderer, lambda x: x['lengthText']['simpleText'], compat_str))
+        duration_text = try_get(
+            renderer, 
+            (lambda x: x['lengthText']['simpleText'], 
+             lambda x: x['thumbnailOverlays'][0]['thumbnailOverlayTimeStatusRenderer']['text']['simpleText']),
+             compat_str)
+        duration = parse_duration(duration_text)
         view_count_text = try_get(
             renderer, lambda x: x['viewCountText']['simpleText'], compat_str) or ''
         view_count = str_to_int(self._search_regex(

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -315,7 +315,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
              lambda x: x['title']['simpleText']), compat_str)
         description = try_get(
             renderer, lambda x: x['descriptionSnippet']['runs'][0]['text'],
-            compat_str) 
+            compat_str)
         duration_text = try_get(
             renderer,
             (lambda x: x['lengthText']['simpleText'],

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -318,7 +318,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             compat_str)
         duration_text = try_get(
             renderer, 
-            (lambda x: x['lengthText']['simpleText'], 
+           (lambda x: x['lengthText']['simpleText'], 
             lambda x: x['thumbnailOverlays'][0]['thumbnailOverlayTimeStatusRenderer']['text']['simpleText']),
             compat_str)
         duration = parse_duration(duration_text)


### PR DESCRIPTION
Early gathering of item video duration values from playlist metadata, prior to downloading individual item metadata pages, so that video durations are (e.g.) shown in --flat-playlist and playlist json export, and/or can be used as a download filtering criterion.